### PR TITLE
Multi-architecture support

### DIFF
--- a/build-debezium.sh
+++ b/build-debezium.sh
@@ -32,7 +32,7 @@ build_docker_image () {
     echo "****************************************************************"
     echo "** Building    debezium/${IMAGE_NAME}:${IMAGE_TAG}"
     echo "****************************************************************"
-    docker build -t "debezium/${IMAGE_NAME}:latest" "${IMAGE_PATH}"
+    docker buildx build --platform linux/amd64,linux/arm64 -t "debezium/${IMAGE_NAME}:latest" "${IMAGE_PATH}"
 
     if [ -z "$RELEASE_TAG" ]; then
         echo "****************************************************************"


### PR DESCRIPTION
Adds multi-architecture support to build-debezium for AMD64 as well as ARM64

The only image that does not work is debezium-ui - but before I go putting effort into either fixing that or working around that, I'd like to know if this type of change would be worth it to the maintainers.