### PR TITLE
DBZ-5213 Adding unique label when building multiarch images 

### DIFF
--- a/build-debezium-multiplatform.sh
+++ b/build-debezium-multiplatform.sh
@@ -72,6 +72,7 @@ build_docker_image () {
     # shellcheck disable=SC2068
     docker buildx build --push --platform "${PLATFORM}" \
       --build-arg DEBEZIUM_DOCKER_REGISTRY_PRIMARY_NAME="$DEBEZIUM_DOCKER_REGISTRY_PRIMARY_NAME" \
+      --label "build-at=$(date +%s)" \
         ${TAGS[@]} \
         "${IMAGE_PATH}"
 }


### PR DESCRIPTION
Similar to https://github.com/docker/build-push-action/issues/452
Which seems to be related to a bug in containerd https://github.com/containerd/containerd/pull/6995

[quay.io](http://quay.io/) probably responds with redirect when pushing a new tag which has a matching hash of already existing tag. This unfortunately causes buildx builder to fail. Based on testing this seems to help. 
