### PR TITLE
DBZ-6047 Upgrade to Kafka 3.5.0

### DIFF
--- a/kafka/2.3/Dockerfile
+++ b/kafka/2.3/Dockerfile
@@ -8,9 +8,9 @@ LABEL maintainer="Debezium Community"
 # MD5 hash taken from http://kafka.apache.org/downloads.html for this version of Kafka
 # These argument defaults can be overruled during build time but compatibility cannot be guaranteed when the defaults are not used.
 #
-ARG KAFKA_VERSION=3.4.0
+ARG KAFKA_VERSION=3.5.0
 ARG SCALA_VERSION=2.13
-ARG SHA512HASH="2C405149C065627CE2125088DFCCE0A4DC23AEBAA72C1157736D5829CB5CBEF273C0915EC55D2D8BA38E5E0524F0720F43E07D7D677439CD2AC7BEA618CAA65B"
+ARG SHA512HASH="7B79BD0844DB683C06C3491955BB183D48A47FA4639D2E241B9F4FF4060C4B70814DAC7D96BEA87DFFCA0C8AE038278C4FABF68D4EA1194228D67D9C3B1D247C"
 
 ENV KAFKA_VERSION=$KAFKA_VERSION \
     SCALA_VERSION=$SCALA_VERSION \
@@ -44,7 +44,7 @@ RUN curl -fSL -o /tmp/kafka.tgz $(curl --stderr /dev/null https://www.apache.org
     echo "$SHA512HASH /tmp/kafka.tgz" | sha512sum -c - &&\
     tar -xzf /tmp/kafka.tgz -C $KAFKA_HOME --strip-components 1 &&\
     rm -f /tmp/kafka.tgz &&\
-    zip -d /kafka/libs/reload4j-1.2.19.jar org/apache/log4j/net/JMSAppender.class org/apache/log4j/net/SocketServer.class org/apache/log4j/net/JMSSink.class 'org/apache/log4j/jdbc/*' 'org/apache/log4j/chainsaw/*' &&\
+    zip -d /kafka/libs/reload4j-1.2.25.jar org/apache/log4j/net/JMSAppender.class org/apache/log4j/net/SocketServer.class org/apache/log4j/net/JMSSink.class 'org/apache/log4j/jdbc/*' 'org/apache/log4j/chainsaw/*' &&\
     chmod -R g+w,o+w $KAFKA_HOME
 
 COPY ./log4j.properties $KAFKA_HOME/config/log4j.properties

--- a/zookeeper/2.3/Dockerfile
+++ b/zookeeper/2.3/Dockerfile
@@ -7,9 +7,9 @@ LABEL maintainer="Debezium Community"
 # Set the version, home directory, and SHA hash.
 # SHA 512 hash from https://www.apache.org/dist/zookeeper/zookeeper-$ZK_VERSION/zookeeper-$ZK_VERSION.tar.gz.sha512
 #
-ENV ZK_VERSION=3.6.3 \
+ENV ZK_VERSION=3.6.4 \
     ZK_HOME=/zookeeper \
-    SHA256HASH=3f7b1b7d9cf5647d52ad0076c922e108fa956e986b5624667c493cf6d8ff09d3ca88f623c79a799fe49c72e868cb3c9d0f77cb69608de74a183b2cbad10bc827
+    SHA256HASH=dec4835a1a23fa69599091d03b35f6c9f4e545d5fa1e149658cffdd7d1044ec31e14f41189aabbf59011dfce6609e6850209008e67cfd0f26270f1558196dcd8
 ENV ZK_URL_PATH=zookeeper/zookeeper-$ZK_VERSION/apache-zookeeper-$ZK_VERSION-bin.tar.gz
 
 #
@@ -47,7 +47,7 @@ RUN echo "$SHA256HASH /tmp/zookeeper.tar.gz" | sha512sum -c - &&\
 #
 # CVE-2021-4104/DBZ-4447 CVE-2019-17571 Remove potentially exploitable classes
 #
-RUN zip -d /zookeeper/lib/log4j-1.2.17.jar org/apache/log4j/net/JMSAppender.class org/apache/log4j/net/SocketServer.class
+RUN zip -d /zookeeper/lib/reload4j-1.2.24.jar org/apache/log4j/net/JMSAppender.class org/apache/log4j/net/SocketServer.class
 
 # Remove unnecessary files
 RUN rm -r $ZK_HOME/docs


### PR DESCRIPTION
[DBZ-6047](https://issues.redhat.com/browse/DBZ-6047)

Depends on https://github.com/debezium/debezium/pull/4617