### PR TITLE
Upgrade Debezium Server's Java version

### DIFF
--- a/server/2.7/Dockerfile
+++ b/server/2.7/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage
-FROM registry.access.redhat.com/ubi8/openjdk-11 AS builder
+FROM registry.access.redhat.com/ubi8/openjdk-17 AS builder
 
 LABEL maintainer="Debezium Community"
 
@@ -49,7 +49,7 @@ RUN echo "$SERVER_MD5 /tmp/debezium.tar.gz" | md5sum -c - &&\
 RUN chmod -R g+w,o+w $SERVER_HOME
 
 # Stage 2: Final image
-FROM registry.access.redhat.com/ubi8/openjdk-11
+FROM registry.access.redhat.com/ubi8/openjdk-17
 
 LABEL maintainer="Debezium Community"
 


### PR DESCRIPTION
upgrade to java17 to get SMT working.

In Java 11, if SMT is enabled, will get this error

`GraalJSEngineFactory has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0'`

Upgrade the java version to 17 to resolve the problem