### PR TITLE
DBZ-8230 Bump apicurio from 2.4.1.Final to 2.6.2.Final

### DIFF
--- a/connect-base/3.0/Dockerfile
+++ b/connect-base/3.0/Dockerfile
@@ -22,7 +22,7 @@ ENV KAFKA_CONNECT_PLUGINS_DIR=$KAFKA_HOME/connect \
     EXTERNAL_LIBS_DIR=$KAFKA_HOME/external_libs \
     CONNECT_PLUGIN_PATH=$KAFKA_CONNECT_PLUGINS_DIR \
     MAVEN_DEP_DESTINATION=$KAFKA_HOME/libs \
-    APICURIO_VERSION=2.4.1.Final \
+    APICURIO_VERSION=2.6.2.Final \
     JOLOKIA_VERSION=1.7.2 \
     OPENTELEMETRY_VERSION=1.23.1 \
     OPENTELEMETRY_INSTRUMENTATION_VERSION=1.23.0
@@ -42,7 +42,7 @@ RUN mkdir "$KAFKA_CONNECT_PLUGINS_DIR" "$EXTERNAL_LIBS_DIR"
 # This will prevent the classes in the shared dependencies from appearing in multiple JARs
 # on the classpath, which results in arcane NoSuchMethodError exceptions.
 #
-RUN docker-maven-download apicurio "$APICURIO_VERSION" ead18a95038adca54e91b7f253717eb7
+RUN docker-maven-download apicurio "$APICURIO_VERSION" 25e9ef205952c6ecb03cfb59098c229f
 RUN docker-maven-download central org/jolokia jolokia-jvm "$JOLOKIA_VERSION" d489d62d1143e6a2e85a869a4b824a67
 RUN docker-maven-download otel io/opentelemetry opentelemetry-api "$OPENTELEMETRY_VERSION" e198a9568ce31a82faaa26f328388e89
 RUN docker-maven-download otel io/opentelemetry opentelemetry-context "$OPENTELEMETRY_VERSION" 783594a506dbf035e686776d5bcb4bfc


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-8230