### PR TITLE
Change mkdir conf for config to match volume

### DIFF
--- a/server/3.0/Dockerfile
+++ b/server/3.0/Dockerfile
@@ -28,7 +28,7 @@ RUN chown -R jboss $SERVER_HOME && \
     chgrp -R jboss $SERVER_HOME
 USER jboss
 
-RUN mkdir $SERVER_HOME/conf && \
+RUN mkdir $SERVER_HOME/config && \
     mkdir $SERVER_HOME/data
 
 #


### PR DESCRIPTION
Creates `config` directory instead of `conf` to match the volume, which was changed in #392