### PR TITLE
Temporarily switch to connect base 3.0

### DIFF
--- a/connect/snapshot/Dockerfile
+++ b/connect/snapshot/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/debezium/connect-base:3.1
+FROM quay.io/debezium/connect-base:3.0
 
 LABEL maintainer="Debezium Community"
 


### PR DESCRIPTION
So we can build conect 3.1 nightly image.
Should be switched back once we publish 3.1 conect-base image.