### PR TITLE
DBZ-8605 Add 3.1 for conductor

### DIFF
--- a/.github/workflows/image-builds-unauth.yml
+++ b/.github/workflows/image-builds-unauth.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [ 'mongo', 'postgres', 'debezium', 'tool' ]
+        component: [ 'mongo', 'postgres', 'debezium', 'tool' 'conductor', 'operator']
     runs-on: ubuntu-latest
     env:
       DEBEZIUM_DOCKER_REGISTRY_PRIMARY_NAME: localhost:5500/debeziumquay

--- a/conductor/3.1/Dockerfile
+++ b/conductor/3.1/Dockerfile
@@ -1,0 +1,122 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./mvnw package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/debezium-platform-conductor-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/debezium-platform-conductor-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/debezium-platform-conductor-jvm
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+# You can configure the behavior using the following environment properties:
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
+#   in JAVA_OPTS (example: "-Dsome.property=foo")
+# - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
+#   used to calculate a default maximal heap memory based on a containers restriction.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio
+#   of the container available memory as set here. The default is `50` which means 50%
+#   of the available memory is used as an upper boundary. You can skip this mechanism by
+#   setting this value to `0` in which case no `-Xmx` option is added.
+# - JAVA_INITIAL_MEM_RATIO: Is used when no `-Xms` option is given in JAVA_OPTS. This
+#   is used to calculate a default initial heap memory based on the maximum heap memory.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xms` is set to a ratio
+#   of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx`
+#   is used as the initial heap size. You can skip this mechanism by setting this value
+#   to `0` in which case no `-Xms` option is added (example: "25")
+# - JAVA_MAX_INITIAL_MEM: Is used when no `-Xms` option is given in JAVA_OPTS.
+#   This is used to calculate the maximum value of the initial heap memory. If used in
+#   a container without any memory constraints for the container then this option has
+#   no effect. If there is a memory constraint then `-Xms` is limited to the value set
+#   here. The default is 4096MB which means the calculated value of `-Xms` never will
+#   be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")
+# - JAVA_DIAGNOSTICS: Set this to get some diagnostics information to standard output
+#   when things are happening. This option, if set to true, will set
+#  `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").
+# - JAVA_DEBUG: If set remote debugging will be switched on. Disabled by default (example:
+#    true").
+# - JAVA_DEBUG_PORT: Port used for remote debugging. Defaults to 5005 (example: "8787").
+# - CONTAINER_CORE_LIMIT: A calculated core limit as described in
+#   https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")
+# - CONTAINER_MAX_MEMORY: Memory limit given to the container (example: "1024").
+# - GC_MIN_HEAP_FREE_RATIO: Minimum percentage of heap free after GC to avoid expansion.
+#   (example: "20")
+# - GC_MAX_HEAP_FREE_RATIO: Maximum percentage of heap free after GC to avoid shrinking.
+#   (example: "40")
+# - GC_TIME_RATIO: Specifies the ratio of the time spent outside the garbage collection.
+#   (example: "4")
+# - GC_ADAPTIVE_SIZE_POLICY_WEIGHT: The weighting given to the current GC time versus
+#   previous GC times. (example: "90")
+# - GC_METASPACE_SIZE: The initial metaspace size. (example: "20")
+# - GC_MAX_METASPACE_SIZE: The maximum metaspace size. (example: "100")
+# - GC_CONTAINER_OPTIONS: Specify Java GC to use. The value of this variable should
+#   contain the necessary JRE command-line options to specify the required GC, which
+#   will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).
+# - HTTPS_PROXY: The location of the https proxy. (example: "myuser@127.0.0.1:8080")
+# - HTTP_PROXY: The location of the http proxy. (example: "myuser@127.0.0.1:8080")
+# - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
+#   accessed directly. (example: "foo.example.com,bar.example.com")
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-21
+LABEL maintainer="Debezium Community"
+
+#
+# Set the version, home directory
+#
+ARG DEBEZIUM_VERSION=3.1.0-SNAPSHOT
+
+ENV LANGUAGE='en_US:en'
+ENV DEBEZIUM_VERSION=$DEBEZIUM_VERSION \
+    DEBEZIUM_PLATFORM_CONDUCTOR_HOME=/debezium-platform-conductor \
+    MAVEN_OSS_SNAPSHOT="https://s01.oss.sonatype.org/content/repositories/snapshots"
+
+USER root
+
+#
+# Prepare environment
+#
+RUN microdnf install -y gzip
+RUN mkdir $DEBEZIUM_PLATFORM_CONDUCTOR_HOME;
+
+#
+# Download the snapshot version of debezium-operator and then install it to the `$DEBEZIUM_PLATFORM_CONDUCTOR_HOME` directory...
+#
+RUN SNAPSHOT_VERSION=$(curl --silent -fSL $MAVEN_OSS_SNAPSHOT/io/debezium/debezium-platform-conductor/$DEBEZIUM_VERSION/maven-metadata.xml | awk -F'<[^>]+>' '/<extension>tar.gz<\/extension>/ {getline; print $2; exit}'); \
+    echo "Downloading and installing debezium-platform-conductor-$SNAPSHOT_VERSION.tar.gz ..." ; \
+    curl --silent -fSL -o /tmp/debezium-platform-conductor.tar.gz  $MAVEN_OSS_SNAPSHOT/io/debezium/debezium-platform-conductor/$DEBEZIUM_VERSION/debezium-platform-conductor-$SNAPSHOT_VERSION.tar.gz && \
+    echo "Extracting debezium-platform-conductor-$SNAPSHOT_VERSION.tar.gz ..." && \
+    tar xzf /tmp/debezium-platform-conductor.tar.gz -C $DEBEZIUM_PLATFORM_CONDUCTOR_HOME --strip-components 1 && \
+    echo "Successfully installed debezium-platform-conductor-$SNAPSHOT_VERSION.tar.gz !" && \
+    rm -f /tmp/debezium-platform-conductor.tar.gz;
+
+#
+# Set the owner on `$DEBEZIUM_PLATFORM_CONDUCTOR_HOME`
+#
+RUN chown -R 185 $DEBEZIUM_PLATFORM_CONDUCTOR_HOME
+
+
+EXPOSE 8080
+USER 185
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="$DEBEZIUM_PLATFORM_CONDUCTOR_HOME/quarkus-run.jar"
+


### PR DESCRIPTION
@jpechane Since the main CI tries to build the latest version, in this case 3.1, the relative folder is required. I preferred to create it so it will be ready for the release. There will be just the changes for repo patch an version. 