### PR TITLE
DBZ-8655 Turn on replication during db initialization

### DIFF
--- a/examples/mysql-replication/master/2.7/inventory.sql
+++ b/examples/mysql-replication/master/2.7/inventory.sql
@@ -4,6 +4,12 @@
 # However, this grant is equivalent to specifying *any* hosts, which makes this easier since the docker host
 # is not easily known to the Docker container. But don't do this in production.
 #
+
+# Oracle Docker image turn replication off while loading initial files, which breaks our replication setup.
+# See https://github.com/mysql/mysql-docker/blob/1.2.20-server/mysql-server/8.4/docker-entrypoint.sh#L109
+# Turn replication on in the init script.
+SET @@SESSION.SQL_LOG_BIN=1;
+
 CREATE USER 'replicator' IDENTIFIED BY 'replpass';
 CREATE USER 'debezium' IDENTIFIED BY 'dbz';
 GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator';

--- a/examples/mysql-replication/master/3.0/inventory.sql
+++ b/examples/mysql-replication/master/3.0/inventory.sql
@@ -4,6 +4,12 @@
 # However, this grant is equivalent to specifying *any* hosts, which makes this easier since the docker host
 # is not easily known to the Docker container. But don't do this in production.
 #
+
+# Oracle Docker image turn replication off while loading initial files, which breaks our replication setup.
+# See https://github.com/mysql/mysql-docker/blob/1.2.20-server/mysql-server/8.4/docker-entrypoint.sh#L109
+# Turn replication on in the init script.
+SET @@SESSION.SQL_LOG_BIN=1;
+
 CREATE USER 'replicator' IDENTIFIED BY 'replpass';
 CREATE USER 'debezium' IDENTIFIED BY 'dbz';
 GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator';

--- a/examples/mysql-replication/master/3.1/inventory.sql
+++ b/examples/mysql-replication/master/3.1/inventory.sql
@@ -4,6 +4,12 @@
 # However, this grant is equivalent to specifying *any* hosts, which makes this easier since the docker host
 # is not easily known to the Docker container. But don't do this in production.
 #
+
+# Oracle Docker image turn replication off while loading initial files, which breaks our replication setup.
+# See https://github.com/mysql/mysql-docker/blob/1.2.20-server/mysql-server/8.4/docker-entrypoint.sh#L109
+# Turn replication on in the init script.
+SET @@SESSION.SQL_LOG_BIN=1;
+
 CREATE USER 'replicator' IDENTIFIED BY 'replpass';
 CREATE USER 'debezium' IDENTIFIED BY 'dbz';
 GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator';


### PR DESCRIPTION
In the new base images replication is turned on (as it's turned on by default), but it's turned off temporarily while it executes initial scripts, so the `inventory` DB and initial data is not created on the replica.

https://issues.redhat.com/browse/DBZ-8655