### PR TITLE
DBZ-9035 Move Debezium base image to Fedora 41

### DIFF
--- a/base/latest/Dockerfile
+++ b/base/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:40
+FROM registry.fedoraproject.org/fedora-minimal:41
 
 LABEL maintainer="Debezium Community"
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-9035