### PR TITLE
[mongo-images] improved rs initialisation for compose environments

### DIFF
--- a/examples/mongodb/3.0/Dockerfile
+++ b/examples/mongodb/3.0/Dockerfile
@@ -2,6 +2,9 @@ FROM mirror.gcr.io/library/mongo:6.0
 
 LABEL maintainer="Debezium Community"
 
+ENV MONGO_INITDB_ROOT_USERNAME=admin
+ENV MONGO_INITDB_ROOT_PASSWORD=admin
+
 COPY init-inventory.sh /usr/local/bin/
 COPY insert-inventory-data.js /usr/local/bin/
 

--- a/examples/mongodb/3.1/Dockerfile
+++ b/examples/mongodb/3.1/Dockerfile
@@ -2,6 +2,9 @@ FROM mirror.gcr.io/library/mongo:6.0
 
 LABEL maintainer="Debezium Community"
 
+ENV MONGO_INITDB_ROOT_USERNAME=admin
+ENV MONGO_INITDB_ROOT_PASSWORD=admin
+
 COPY init-inventory.sh /usr/local/bin/
 COPY insert-inventory-data.js /usr/local/bin/
 

--- a/examples/mongodb/3.2/Dockerfile
+++ b/examples/mongodb/3.2/Dockerfile
@@ -2,6 +2,9 @@ FROM mirror.gcr.io/library/mongo:6.0
 
 LABEL maintainer="Debezium Community"
 
+ENV MONGO_INITDB_ROOT_USERNAME=admin
+ENV MONGO_INITDB_ROOT_PASSWORD=admin
+
 COPY init-inventory.sh /usr/local/bin/
 COPY insert-inventory-data.js /usr/local/bin/
 


### PR DESCRIPTION
Based on discussion with @AlvarVG  this will enable "init" container to be used in compose environments so the initialisation can be automated and doesn't require manual script execution.

Summary:

- admin user is now created via env variables 
- init script adjusted for remote execution