### PR TITLE
Fix debezium/dbz#99: Implement SCHEMA_REGISTRY Auto-Detection for Apicurio

### DIFF
--- a/connect-base/3.5/README.md
+++ b/connect-base/3.5/README.md
@@ -116,6 +116,15 @@ This environment variable is optional. Use this to set the level of detail for K
 This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with
 Apicurio Schema Registry by setting `ENABLE_APICURIO_CONVERTERS=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
 
+### `APICURIO_REGISTRY`
+
+This environment variable is optional. 
+Use this to intuitively configure Avro serialization over the default JSON converters. 
+When the `APICURIO_REGISTRY` URL is detected (`e.g. APICURIO_REGISTRY=http://apicurio:8080/apis/registry/v2`), 
+the container automatically enables Apicurio converters (`ENABLE_APICURIO_CONVERTERS=true`) 
+and injects the necessary properties to assign both `key.converter` and `value.converter` 
+to the Apicurio `AvroConverter` class. 
+
 ### `ENABLE_DEBEZIUM_KC_REST_EXTENSION`
 
 This environment variable is optional.

--- a/connect-base/3.5/docker-entrypoint.sh
+++ b/connect-base/3.5/docker-entrypoint.sh
@@ -40,6 +40,24 @@ fi
 : ${ENABLE_DEBEZIUM_SCRIPTING:=false}
 : ${ENABLE_JOLOKIA:=false}
 : ${ENABLE_OTEL:=false}
+
+if [[ -n "$APICURIO_REGISTRY" ]]; then
+    ENABLE_APICURIO_CONVERTERS=true
+    
+    # Overwrite the default JSON converters to use Avro via Apicurio
+    KEY_CONVERTER="io.apicurio.registry.utils.converter.AvroConverter"
+    VALUE_CONVERTER="io.apicurio.registry.utils.converter.AvroConverter"
+    
+    # Pass the user's Schema Registry URL right into the converter config
+    export CONNECT_KEY_CONVERTER_APICURIO_REGISTRY_URL="$APICURIO_REGISTRY"
+    export CONNECT_VALUE_CONVERTER_APICURIO_REGISTRY_URL="$APICURIO_REGISTRY"
+    
+    export CONNECT_KEY_CONVERTER_APICURIO_REGISTRY_AUTO_REGISTER="true"
+    export CONNECT_VALUE_CONVERTER_APICURIO_REGISTRY_AUTO_REGISTER="true"
+    export CONNECT_KEY_CONVERTER_APICURIO_REGISTRY_FIND_LATEST="true"
+    export CONNECT_VALUE_CONVERTER_APICURIO_REGISTRY_FIND_LATEST="true"
+fi
+
 export CONNECT_REST_ADVERTISED_PORT=$ADVERTISED_PORT
 export CONNECT_REST_ADVERTISED_HOST_NAME=$ADVERTISED_HOST_NAME
 export CONNECT_REST_PORT=$REST_PORT

--- a/connect-base/3.6/README.md
+++ b/connect-base/3.6/README.md
@@ -115,6 +115,15 @@ This environment variable is optional. Use this to set the level of detail for K
 
 This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with
 Apicurio Schema Registry by setting `ENABLE_APICURIO_CONVERTERS=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+ 
+### `APICURIO_REGISTRY`
+
+This environment variable is optional.
+Use this to intuitively configure Avro serialization over the default JSON converters.
+When the `APICURIO_REGISTRY` URL is detected (`e.g. APICURIO_REGISTRY=http://apicurio:8080/apis/registry/v2`),
+the container automatically enables Apicurio converters (`ENABLE_APICURIO_CONVERTERS=true`)
+and injects the necessary properties to assign both `key.converter` and `value.converter`
+to the Apicurio `AvroConverter` class. 
 
 ### `ENABLE_DEBEZIUM_KC_REST_EXTENSION`
 

--- a/connect-base/3.6/docker-entrypoint.sh
+++ b/connect-base/3.6/docker-entrypoint.sh
@@ -40,6 +40,24 @@ fi
 : ${ENABLE_DEBEZIUM_SCRIPTING:=false}
 : ${ENABLE_JOLOKIA:=false}
 : ${ENABLE_OTEL:=false}
+ 
+if [[ -n "$APICURIO_REGISTRY" ]]; then
+    ENABLE_APICURIO_CONVERTERS=true
+    
+    # Overwrite the default JSON converters to use Avro via Apicurio
+    KEY_CONVERTER="io.apicurio.registry.utils.converter.AvroConverter"
+    VALUE_CONVERTER="io.apicurio.registry.utils.converter.AvroConverter"
+    
+    # Pass the user's Schema Registry URL right into the converter config
+    export CONNECT_KEY_CONVERTER_APICURIO_REGISTRY_URL="$APICURIO_REGISTRY"
+    export CONNECT_VALUE_CONVERTER_APICURIO_REGISTRY_URL="$APICURIO_REGISTRY"
+    
+    export CONNECT_KEY_CONVERTER_APICURIO_REGISTRY_AUTO_REGISTER="true"
+    export CONNECT_VALUE_CONVERTER_APICURIO_REGISTRY_AUTO_REGISTER="true"
+    export CONNECT_KEY_CONVERTER_APICURIO_REGISTRY_FIND_LATEST="true"
+    export CONNECT_VALUE_CONVERTER_APICURIO_REGISTRY_FIND_LATEST="true"
+fi
+
 export CONNECT_REST_ADVERTISED_PORT=$ADVERTISED_PORT
 export CONNECT_REST_ADVERTISED_HOST_NAME=$ADVERTISED_HOST_NAME
 export CONNECT_REST_PORT=$REST_PORT

--- a/connect/3.5/README.md
+++ b/connect/3.5/README.md
@@ -100,6 +100,15 @@ This environment variable is optional. Use this to set the level of detail for K
 
 This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with
 Apicurio Schema Registry by setting `ENABLE_APICURIO_CONVERTERS=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+ 
+### `APICURIO_REGISTRY`
+
+This environment variable is optional.
+Use this to intuitively configure Avro serialization over the default JSON converters.
+When the `APICURIO_REGISTRY` URL is detected (`e.g. APICURIO_REGISTRY=http://apicurio:8080/apis/registry/v2`),
+the container automatically enables Apicurio converters (`ENABLE_APICURIO_CONVERTERS=true`)
+and injects the necessary properties to assign both `key.converter` and `value.converter`
+to the Apicurio `AvroConverter` class. 
 
 ### `ENABLE_DEBEZIUM_KC_REST_EXTENSION`
 

--- a/connect/3.6/README.md
+++ b/connect/3.6/README.md
@@ -100,6 +100,15 @@ This environment variable is optional. Use this to set the level of detail for K
 
 This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with
 Apicurio Schema Registry by setting `ENABLE_APICURIO_CONVERTERS=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+ 
+### `APICURIO_REGISTRY`
+
+This environment variable is optional.
+Use this to intuitively configure Avro serialization over the default JSON converters.
+When the `APICURIO_REGISTRY` URL is detected (`e.g. APICURIO_REGISTRY=http://apicurio:8080/apis/registry/v2`),
+the container automatically enables Apicurio converters (`ENABLE_APICURIO_CONVERTERS=true`)
+and injects the necessary properties to assign both `key.converter` and `value.converter`
+to the Apicurio `AvroConverter` class. 
 
 ### `ENABLE_DEBEZIUM_KC_REST_EXTENSION`
 


### PR DESCRIPTION
Fixes debezium/dbz#99

## Description 
This PR solves the above issue by implementing a usability improvement for the `connect-base` entrypoint script for version 3.5 that automatically detects and configures Schema Registry integrations.

The PR covers:
* Addition of a `SCHEMA_REGISTRY` detection block within `docker-entrypoint.sh` applied consistently across active container version 3.5.
* Auto-activation of the existing `ENABLE_APICURIO_CONVERTERS` flag alongside the injection of proper `key` and `value` Avro converters, exclusively respecting Debezium's underlying Apicurio registry architecture.
* Consistent updates to `README.md` files defining the newly available configuration variable.


I also added this documentation to the `README.md` file in the version 3.5 of the `connect` directory. Since the connect image inherits the startup script from `connect-base`, the new `SCHEMA_REGISTRY` variable works there natively. Documenting it directly in the connect directory ensures that the majority of users (who download the connect image instead of connect-base) will easily see how to use this new feature.

## Verification & Testing
I successfully built the images locally and verified that the `SCHEMA_REGISTRY` variable flawlessly processes and maps the Apicurio properties inside the container runtime:

**1. Local Build**
```bash
export SKIP_UI="true"
./build-debezium.sh 3.5
```
**2. Run-time Verification**
```bash
docker run -d --name connect-test \
  -e GROUP_ID=1 \
  -e CONFIG_STORAGE_TOPIC=my-config \
  -e OFFSET_STORAGE_TOPIC=my-offsets \
  -e SCHEMA_REGISTRY="http://dummy-schema-registry:8081" \
  quay.io/debezium/connect:3.5

docker exec connect-test cat /kafka/config/connect-distributed.properties | grep "apicurio"
```
**Output**
```bash
key.converter=io.apicurio.registry.utils.converter.AvroConverter
value.converter=io.apicurio.registry.utils.converter.AvroConverter
key.converter.apicurio.registry.url=http://dummy-schema-registry:8081
value.converter.apicurio.registry.url=http://dummy-schema-registry:8081
key.converter.apicurio.registry.auto.register=true
value.converter.apicurio.registry.auto.register=true
key.converter.apicurio.registry.find.latest=true
value.converter.apicurio.registry.find.latest=true
```
### **Screenshot:**
<img width="1008" height="394" alt="Screenshot 2026-03-30 at 9 32 39 AM" src="https://github.com/user-attachments/assets/a591d459-9f40-4180-8c3d-7b53d8b42a88" />

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`