### PR TITLE
debezium/dbz#1660 Re-enable OTEL installation at build time

### DIFF
--- a/server/3.5/Dockerfile
+++ b/server/3.5/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-21 AS builder
 
 LABEL maintainer="Debezium Community"
 
-ARG OTEL_ENABLED=false
+ARG OTEL_ENABLED=true
 
 #
 # Set the version, home directory, and MD5 hash.
@@ -70,7 +70,8 @@ LABEL maintainer="Debezium Community"
 
 ENV DEBEZIUM_VERSION=3.5.0.Final \
     SERVER_HOME=/debezium \
-    MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2"
+    MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2" \
+    OTEL_SDK_DISABLED=true
 
 USER root
 RUN microdnf clean all

--- a/server/3.6/Dockerfile
+++ b/server/3.6/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-21 AS builder
 
 LABEL maintainer="Debezium Community"
 
-ARG OTEL_ENABLED=false
+ARG OTEL_ENABLED=true
 
 #
 # Set the version, home directory, and MD5 hash.
@@ -70,7 +70,8 @@ LABEL maintainer="Debezium Community"
 
 ENV DEBEZIUM_VERSION=3.5.0.Final \
     SERVER_HOME=/debezium \
-    MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2"
+    MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2" \
+    OTEL_SDK_DISABLED=true
 
 USER root
 RUN microdnf clean all


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/1660

> @seandstewart @tomflenner I am sorry I disabled by default. The reason is that the image is now a bit problematic to be used when OTEL is not present.
> So my recommendation is to provide a follow-up PR that will
> - enable OTEL back in the build time by default
> - disable OTEL in the runtime by default
