### PR TITLE
debezium/dbz#1895 Remove OTel agent instrumentation since is now enabled in the Debezium Server distribution

### DIFF
--- a/server/3.6/Dockerfile
+++ b/server/3.6/Dockerfile
@@ -3,16 +3,12 @@ FROM registry.access.redhat.com/ubi8/openjdk-21 AS builder
 
 LABEL maintainer="Debezium Community"
 
-ARG OTEL_ENABLED=true
-
 #
 # Set the version, home directory, and MD5 hash.
 #
 ENV DEBEZIUM_VERSION=3.6.0.Alpha1 \
     SERVER_HOME=/debezium \
-    MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2" \
-    OPENTELEMETRY_AGENT_VERSION=2.25.0 \
-    OPENTELEMETRY_MD5=a7f1cbab5448e61d93e71ffdff9175b6
+    MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2"
 ENV SERVER_URL_PATH=io/debezium/debezium-server-dist/$DEBEZIUM_VERSION/debezium-server-dist-$DEBEZIUM_VERSION.tar.gz \
     SERVER_MD5=6f88172d63aede70eaee23f0dd0603bb
 
@@ -48,17 +44,6 @@ RUN echo "$SERVER_MD5 /tmp/debezium.tar.gz" | md5sum -c - &&\
     rm -f /tmp/debezium.tar.gz
 
 #
-# Download the OpenTelemetry Java agent and wire it into run.sh via JAVA_OPTS
-#
-RUN if [ "$OTEL_ENABLED" = "true" ]; then \
-       mkdir $SERVER_HOME/otel \
-       && curl -fSL -o $SERVER_HOME/otel/opentelemetry-javaagent.jar \
-           https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/$OPENTELEMETRY_AGENT_VERSION/opentelemetry-javaagent-$OPENTELEMETRY_AGENT_VERSION.jar \
-       && echo "$OPENTELEMETRY_MD5 $SERVER_HOME/otel/opentelemetry-javaagent.jar" | md5sum -c - \
-       && sed -i "/^exec/i JAVA_OPTS=\"\$JAVA_OPTS -javaagent:$SERVER_HOME/otel/opentelemetry-javaagent.jar\"" $SERVER_HOME/run.sh; \
-    fi
-
-#
 # Allow random UID to use Debezium Server
 #
 RUN chmod -R g+w,o+w $SERVER_HOME
@@ -71,6 +56,7 @@ LABEL maintainer="Debezium Community"
 ENV DEBEZIUM_VERSION=3.6.0.Alpha1 \
     SERVER_HOME=/debezium \
     MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2" \
+    OTEL_ENABLED=true \
     OTEL_SDK_DISABLED=true
 
 USER root


### PR DESCRIPTION
Fixes: debezium/dbz#1895