### PR TITLE
debezium/dbz#1938 Add Connect chronicle queue env variable

### DIFF
--- a/connect-base/3.6/README.md
+++ b/connect-base/3.6/README.md
@@ -146,6 +146,17 @@ This feature is useful for gathering of diagnostic information in case of perfor
 Flight Recorder start options can be configured via `JFR_RECORDING_` prefixed environment variables when the variables is converted to lowercase and underscores are replaced with dashes, e.g. `JFR_RECORDING_PATH_TO_GC_ROOTS=true` becomes `path-to-gc-roots=true`.
 Flight Recorder control options can be configured via `JFR_OPT_` prefixed environment variables.
 
+### `ENABLE_CHRONICLE_QUEUE`
+
+This environment variable is optional.
+Use this to enable Debezium's Chronicle Queue storage module, providing disk-based persistence for the change event queue during high-volume dispatch by setting `ENABLE_CHRONICLE_QUEUE=true` as a container environment variable.
+Valid values are `false` to disable (the default) or `true` to enable disk-based persistence.
+
+Note: Chronicle Queue requires the mounted path to not be a network-based file system.
+This includes NFS, AFS, SAN_based storage, or similar.
+The reason is those systems do not provide all the required primitives for memory-mapped files that Chronicle Queue requires.
+If any networking is needed to make the files accessible to the container, then Chronicle Queue cannot be used.
+
 ### Others
 
 Environment variables that start with `CONNECT_` will be used to update the Kafka Connect worker configuration file. Each environment variable name will be mapped to a configuration property name by:

--- a/connect-base/3.6/docker-entrypoint.sh
+++ b/connect-base/3.6/docker-entrypoint.sh
@@ -40,6 +40,7 @@ fi
 : ${ENABLE_DEBEZIUM_SCRIPTING:=false}
 : ${ENABLE_JOLOKIA:=false}
 : ${ENABLE_OTEL:=false}
+: ${ENABLE_CHRONICLE_QUEUE:=false}
  
 if [[ -n "$APICURIO_REGISTRY" ]]; then
     ENABLE_APICURIO_CONVERTERS=true
@@ -137,6 +138,7 @@ echo "Plugins are loaded from $CONNECT_PLUGIN_PATH"
 set_connector_additonal_resource_availability $ENABLE_APICURIO_CONVERTERS "apicurio" "*" "Apicurio connectors"
 set_connector_additonal_resource_availability $ENABLE_DEBEZIUM_SCRIPTING "debezium-scripting" "*.jar" "Debezium Scripting"
 set_connector_additonal_resource_availability $ENABLE_OTEL "otel" "*.jar" "OpenTelemetry"
+set_connector_additonal_resource_availability $ENABLE_CHRONICLE_QUEUE "debezium-storage-chronicle-queue" "*.jar" "Chronicle Queue"
 
 #
 # Set up the JMX options
@@ -186,6 +188,19 @@ fi
 if [ "$ENABLE_JOLOKIA" = "true" ]; then
   KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$KAFKA_HOME"/libs/jolokia-jvm-*.jar)=port=8778,host=*"
   export KAFKA_OPTS
+fi
+
+#
+# Setup Chronicle Queue
+#
+if [ "$ENABLE_CHRONICLE_QUEUE" = "true" ]; then
+  KAFKA_OPTS="${KAFKA_OPTS} --add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+  KAFKA_OPTS="${KAFKA_OPTS} --add-opens=java.base/java.lang=ALL-UNNAMED"
+  KAFKA_OPTS="${KAFKA_OPTS} --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
+  KAFKA_OPTS="${KAFKA_OPTS} --add-opens=java.base/java.io=ALL-UNNAMED"
+  KAFKA_OPTS="${KAFKA_OPTS} --add-opens=java.base/java.util=ALL-UNNAMED"
+  export KAFKA_OPTS
+  echo "Chronicle Queue enabled!"
 fi
 
 #

--- a/connect/3.6/Dockerfile
+++ b/connect/3.6/Dockerfile
@@ -19,7 +19,8 @@ ENV DEBEZIUM_VERSION="3.6.0.Alpha2" \
     INFORMIX_MD5=72f05d727a7b6448a34e1626e73d9591 \
     IBMI_MD5=cd97144bb6157bc7efbeddbd3e51903e \
     COCKROACHDB_MD5=73a92c86006bb22782f281f15c848970 \
-    SCRIPTING_MD5=d1afe6663661cf78ca31e0a7f3e6436e
+    SCRIPTING_MD5=d1afe6663661cf78ca31e0a7f3e6436e \
+    CHRONICLE_QUEUE_MD5=TBD
 
 RUN docker-maven-download debezium mongodb "$DEBEZIUM_VERSION" "$MONGODB_MD5" && \
     docker-maven-download debezium mysql "$DEBEZIUM_VERSION" "$MYSQL_MD5" && \
@@ -34,5 +35,6 @@ RUN docker-maven-download debezium mongodb "$DEBEZIUM_VERSION" "$MONGODB_MD5" &&
     docker-maven-download debezium-additional informix informix "$DEBEZIUM_VERSION" "$INFORMIX_MD5" && \
     docker-maven-download debezium-additional ibmi ibmi "$DEBEZIUM_VERSION" "$IBMI_MD5" && \
     docker-maven-download debezium-additional cockroachdb cockroachdb "$DEBEZIUM_VERSION" "$COCKROACHDB_MD5" && \
-    docker-maven-download debezium-optional scripting "$DEBEZIUM_VERSION" "$SCRIPTING_MD5"
+    docker-maven-download debezium-optional scripting "$DEBEZIUM_VERSION" "$SCRIPTING_MD5" && \
+    docker-maven-download debezium-optional storage-chronicle-queue "$DEBEZIUM_VERSION" "$CHRONICLE_QUEUE_MD5"
 

--- a/connect/3.6/Dockerfile
+++ b/connect/3.6/Dockerfile
@@ -20,7 +20,7 @@ ENV DEBEZIUM_VERSION="3.6.0.Alpha2" \
     IBMI_MD5=cd97144bb6157bc7efbeddbd3e51903e \
     COCKROACHDB_MD5=73a92c86006bb22782f281f15c848970 \
     SCRIPTING_MD5=d1afe6663661cf78ca31e0a7f3e6436e \
-    CHRONICLE_QUEUE_MD5=TBD
+    CHRONICLE_QUEUE_MD5=33967e127dfe963f94b9feb5b26964ed
 
 RUN docker-maven-download debezium mongodb "$DEBEZIUM_VERSION" "$MONGODB_MD5" && \
     docker-maven-download debezium mysql "$DEBEZIUM_VERSION" "$MYSQL_MD5" && \

--- a/server/3.6/README.md
+++ b/server/3.6/README.md
@@ -124,6 +124,18 @@ This environment variable is the JMX host set for `java.rmi.server.hostname`.
 
 This environment variable is the JMX port set for `com.sun.management.jmxremote.port` and `com.sun.management.jmxremote.rmi.port`.
 
+### `ENABLE_CHRONICLE_QUEUE`
+
+This environment variable is optional.
+Use this to enable Debezium's Chronicle Queue storage module, providing disk-based persistence for the change event queue during high-volume dispatch by setting `ENABLE_CHRONICLE_QUEUE=true` as a container environment variable.
+Valid values are `false` to disable (the default) or `true` to enable disk-based persistence.
+
+Note: Chronicle Queue requires the mounted path to not be a network-based file system.
+This includes NFS, AFS, SAN_based storage, or similar.
+The reason is those systems do not provide all the required primitives for memory-mapped files that Chronicle Queue requires.
+If any networking is needed to make the files accessible to the container, then Chronicle Queue cannot be used.
+
+
 ### Source/sink Configuration options
 
 All configuration options that could be present in `application.properties` can be either added or overridden via environment variables.


### PR DESCRIPTION
Fixes debezium/dbz#1938

Depends on https://github.com/debezium/debezium/pull/7438/, and requires a MD5 value for Chronicle Queue storage module auto installation.