### PR TITLE
Document OTEL_SDK_DISABLED for server images 3.5 to 3.7

### DIFF
--- a/server/3.5/README.md
+++ b/server/3.5/README.md
@@ -82,10 +82,14 @@ Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the a
 The agent is configured exclusively through environment variables passed to the container.
 See the [OpenTelemetry SDK environment variable reference](https://opentelemetry.io/docs/languages/java/configuration/) for the full list.
 
+Although the agent is installed at build time, telemetry export ist **disabled at runtime by default** via the environment variable `OTEL_SDK_DISABLED`.
+To enable it, set `OTEL_SDK_DISABLED=false`.
+
 Common variables:
 
 | Variable | Description | Example |
 |---|---|---|
+| `OTEL_SDK_DISABLED` | Enables the SDK | `false` |
 | `OTEL_SERVICE_NAME` | Service name reported in traces/metrics | `debezium-server` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://otel-collector:4317` |
 | `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `logging`, `none`) | `otlp` |
@@ -97,6 +101,7 @@ Common variables:
     $ docker run -it --name debezium -p 8080:8080 \
         -v $PWD/config:/debezium/config \
         -v $PWD/data:/debezium/data \
+        -e OTEL_SDK_DISABLED=false \
         -e OTEL_SERVICE_NAME=debezium-server \
         -e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
         quay.io/debezium/server

--- a/server/3.5/README.md
+++ b/server/3.5/README.md
@@ -89,7 +89,7 @@ Common variables:
 
 | Variable | Description | Example |
 |---|---|---|
-| `OTEL_SDK_DISABLED` | Enables the SDK | `false` |
+| `OTEL_SDK_DISABLED` | Disables the OpenTelemetry SDK when set to `true` | `false` |
 | `OTEL_SERVICE_NAME` | Service name reported in traces/metrics | `debezium-server` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://otel-collector:4317` |
 | `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `logging`, `none`) | `otlp` |

--- a/server/3.6/README.md
+++ b/server/3.6/README.md
@@ -82,10 +82,14 @@ Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the a
 The agent is configured exclusively through environment variables passed to the container.
 See the [OpenTelemetry SDK environment variable reference](https://opentelemetry.io/docs/languages/java/configuration/) for the full list.
 
+Although the agent is installed at build time, telemetry export ist **disabled at runtime by default** via the environment variable `OTEL_SDK_DISABLED`.
+To enable it, set `OTEL_SDK_DISABLED=false`.
+
 Common variables:
 
 | Variable | Description | Example |
 |---|---|---|
+| `OTEL_SDK_DISABLED` | Enables the SDK | `false` |
 | `OTEL_SERVICE_NAME` | Service name reported in traces/metrics | `debezium-server` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://otel-collector:4317` |
 | `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `logging`, `none`) | `otlp` |
@@ -97,6 +101,7 @@ Common variables:
     $ docker run -it --name debezium -p 8080:8080 \
         -v $PWD/config:/debezium/config \
         -v $PWD/data:/debezium/data \
+        -e OTEL_SDK_DISABLED=false \
         -e OTEL_SERVICE_NAME=debezium-server \
         -e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
         quay.io/debezium/server

--- a/server/3.6/README.md
+++ b/server/3.6/README.md
@@ -67,12 +67,13 @@ Start the Debezium Server:
 
 # OpenTelemetry (OTEL) support
 
-The image ships with the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) bundled at `/debezium/otel/opentelemetry-javaagent.jar`.
+The image ships with the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) bundled at `/debezium/lib_metrics/opentelemetry-javaagent.jar`.
 
 ## Enabling / disabling the agent
 
-The agent is **enabled by default** (`OTEL_ENABLED=yes` at image build time).
-To build an image without the agent, pass `--build-arg OTEL_ENABLED=no` to `docker build`.
+The `OTEL_ENABLED` environment variable controls whether the agent is loaded at runtime. It is enabled by default. Set `OTEL_ENABLED=false` to prevent the agent from being loaded.
+
+Loading the agent does not enable telemetry by itself. Telemetry is disabled by default through `OTEL_SDK_DISABLED=true`. Set `OTEL_SDK_DISABLED=false` to enable the OpenTelemetry SDK and activate telemetry.
 
 When the agent is enabled it is wired into `JAVA_OPTS` at build time, so it is always active at runtime.
 Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the agent flag.
@@ -82,14 +83,12 @@ Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the a
 The agent is configured exclusively through environment variables passed to the container.
 See the [OpenTelemetry SDK environment variable reference](https://opentelemetry.io/docs/languages/java/configuration/) for the full list.
 
-Although the agent is installed at build time, telemetry export ist **disabled at runtime by default** via the environment variable `OTEL_SDK_DISABLED`.
-To enable it, set `OTEL_SDK_DISABLED=false`.
-
 Common variables:
 
 | Variable | Description | Example |
 |---|---|---|
-| `OTEL_SDK_DISABLED` | Enables the SDK | `false` |
+| `OTEL_ENABLED` | Decides if the agent is loaded | `true` |
+| `OTEL_SDK_DISABLED` | Disables the OpenTelemetry SDK when set to `true` | `false` |
 | `OTEL_SERVICE_NAME` | Service name reported in traces/metrics | `debezium-server` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://otel-collector:4317` |
 | `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `logging`, `none`) | `otlp` |

--- a/server/3.7/README.md
+++ b/server/3.7/README.md
@@ -82,10 +82,14 @@ Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the a
 The agent is configured exclusively through environment variables passed to the container.
 See the [OpenTelemetry SDK environment variable reference](https://opentelemetry.io/docs/languages/java/configuration/) for the full list.
 
+Although the agent is installed at build time, telemetry export ist **disabled at runtime by default** via the environment variable `OTEL_SDK_DISABLED`.
+To enable it, set `OTEL_SDK_DISABLED=false`.
+
 Common variables:
 
 | Variable | Description | Example |
 |---|---|---|
+| `OTEL_SDK_DISABLED` | Enables the SDK | `false` |
 | `OTEL_SERVICE_NAME` | Service name reported in traces/metrics | `debezium-server` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://otel-collector:4317` |
 | `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `logging`, `none`) | `otlp` |
@@ -97,6 +101,7 @@ Common variables:
     $ docker run -it --name debezium -p 8080:8080 \
         -v $PWD/config:/debezium/config \
         -v $PWD/data:/debezium/data \
+        -e OTEL_SDK_DISABLED=false \
         -e OTEL_SERVICE_NAME=debezium-server \
         -e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
         quay.io/debezium/server

--- a/server/3.7/README.md
+++ b/server/3.7/README.md
@@ -67,12 +67,13 @@ Start the Debezium Server:
 
 # OpenTelemetry (OTEL) support
 
-The image ships with the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) bundled at `/debezium/otel/opentelemetry-javaagent.jar`.
+The image ships with the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) bundled at `/debezium/lib_metrics/opentelemetry-javaagent.jar`.
 
 ## Enabling / disabling the agent
 
-The agent is **enabled by default** (`OTEL_ENABLED=yes` at image build time).
-To build an image without the agent, pass `--build-arg OTEL_ENABLED=no` to `docker build`.
+The `OTEL_ENABLED` environment variable controls whether the agent is loaded at runtime. It is enabled by default. Set `OTEL_ENABLED=false` to prevent the agent from being loaded.
+
+Loading the agent does not enable telemetry by itself. Telemetry is disabled by default through `OTEL_SDK_DISABLED=true`. Set `OTEL_SDK_DISABLED=false` to enable the OpenTelemetry SDK and activate telemetry.
 
 When the agent is enabled it is wired into `JAVA_OPTS` at build time, so it is always active at runtime.
 Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the agent flag.
@@ -82,14 +83,12 @@ Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the a
 The agent is configured exclusively through environment variables passed to the container.
 See the [OpenTelemetry SDK environment variable reference](https://opentelemetry.io/docs/languages/java/configuration/) for the full list.
 
-Although the agent is installed at build time, telemetry export ist **disabled at runtime by default** via the environment variable `OTEL_SDK_DISABLED`.
-To enable it, set `OTEL_SDK_DISABLED=false`.
-
 Common variables:
 
 | Variable | Description | Example |
 |---|---|---|
-| `OTEL_SDK_DISABLED` | Enables the SDK | `false` |
+| `OTEL_ENABLED` | Decides if the agent is loaded | `true` |
+| `OTEL_SDK_DISABLED` | Disables the OpenTelemetry SDK when set to `true` | `false` |
 | `OTEL_SERVICE_NAME` | Service name reported in traces/metrics | `debezium-server` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://otel-collector:4317` |
 | `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `logging`, `none`) | `otlp` |

--- a/server/snapshot/Dockerfile
+++ b/server/snapshot/Dockerfile
@@ -74,7 +74,9 @@ FROM registry.access.redhat.com/ubi8/openjdk-21
 LABEL maintainer="Debezium Community"
 
 ENV SERVER_HOME=/debezium \
-    MAVEN_OSS_SNAPSHOT="https://central.sonatype.com/repository/maven-snapshots"
+    MAVEN_OSS_SNAPSHOT="https://central.sonatype.com/repository/maven-snapshots" \
+    OTEL_ENABLED=true \
+    OTEL_SDK_DISABLED=true
 
 USER root
 RUN microdnf clean all

--- a/server/snapshot/README.md
+++ b/server/snapshot/README.md
@@ -65,6 +65,48 @@ Start the Debezium Server:
     $ docker run -it --name debezium -p 8080:8080 -v $PWD/confing:/debezium/confing -v $PWD/data:/debezium/data --link postgres --link pulsar quay.io/debezium/server
 
 
+# OpenTelemetry (OTEL) support
+
+The image ships with the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) bundled at `/debezium/otel/opentelemetry-javaagent.jar`.
+
+## Enabling / disabling the agent
+
+The agent is **enabled by default** (`OTEL_ENABLED=yes` at image build time).
+To build an image without the agent, pass `--build-arg OTEL_ENABLED=no` to `docker build`.
+
+When the agent is enabled it is wired into `JAVA_OPTS` at build time, so it is always active at runtime.
+Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the agent flag.
+
+## Configuring the agent at runtime
+
+The agent is configured exclusively through environment variables passed to the container.
+See the [OpenTelemetry SDK environment variable reference](https://opentelemetry.io/docs/languages/java/configuration/) for the full list.
+
+Although the agent is installed at build time, telemetry export ist **disabled at runtime by default** via the environment variable `OTEL_SDK_DISABLED`.
+To enable it, set `OTEL_SDK_DISABLED=false`.
+
+Common variables:
+
+| Variable | Description | Example |
+|---|---|---|
+| `OTEL_SDK_DISABLED` | Enables the SDK | `false` |
+| `OTEL_SERVICE_NAME` | Service name reported in traces/metrics | `debezium-server` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://otel-collector:4317` |
+| `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `logging`, `none`) | `otlp` |
+| `OTEL_METRICS_EXPORTER` | Metrics exporter (`otlp`, `logging`, `none`) | `otlp` |
+| `OTEL_LOGS_EXPORTER` | Logs exporter (`otlp`, `logging`, `none`) | `otlp` |
+
+### Example — send telemetry to an OTLP collector
+
+    $ docker run -it --name debezium -p 8080:8080 \
+        -v $PWD/config:/debezium/config \
+        -v $PWD/data:/debezium/data \
+        -e OTEL_SDK_DISABLED=false \
+        -e OTEL_SERVICE_NAME=debezium-server \
+        -e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 \
+        quay.io/debezium/server
+
+
 # Environment variables
 
 The Debezium Server image uses several environment variables to configure JVM and source/sink when running this image.

--- a/server/snapshot/README.md
+++ b/server/snapshot/README.md
@@ -67,12 +67,13 @@ Start the Debezium Server:
 
 # OpenTelemetry (OTEL) support
 
-The image ships with the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) bundled at `/debezium/otel/opentelemetry-javaagent.jar`.
+The image ships with the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) bundled at `/debezium/lib_metrics/opentelemetry-javaagent.jar`.
 
 ## Enabling / disabling the agent
 
-The agent is **enabled by default** (`OTEL_ENABLED=yes` at image build time).
-To build an image without the agent, pass `--build-arg OTEL_ENABLED=no` to `docker build`.
+The `OTEL_ENABLED` environment variable controls whether the agent is loaded at runtime. It is enabled by default. Set `OTEL_ENABLED=false` to prevent the agent from being loaded.
+
+Loading the agent does not enable telemetry by itself. Telemetry is disabled by default through `OTEL_SDK_DISABLED=true`. Set `OTEL_SDK_DISABLED=false` to enable the OpenTelemetry SDK and activate telemetry.
 
 When the agent is enabled it is wired into `JAVA_OPTS` at build time, so it is always active at runtime.
 Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the agent flag.
@@ -82,14 +83,12 @@ Passing `-e JAVA_OPTS=...` at `docker run` will add to — not replace — the a
 The agent is configured exclusively through environment variables passed to the container.
 See the [OpenTelemetry SDK environment variable reference](https://opentelemetry.io/docs/languages/java/configuration/) for the full list.
 
-Although the agent is installed at build time, telemetry export ist **disabled at runtime by default** via the environment variable `OTEL_SDK_DISABLED`.
-To enable it, set `OTEL_SDK_DISABLED=false`.
-
 Common variables:
 
 | Variable | Description | Example |
 |---|---|---|
-| `OTEL_SDK_DISABLED` | Enables the SDK | `false` |
+| `OTEL_ENABLED` | Decides if the agent is loaded | `true` |
+| `OTEL_SDK_DISABLED` | Disables the OpenTelemetry SDK when set to `true` | `false` |
 | `OTEL_SERVICE_NAME` | Service name reported in traces/metrics | `debezium-server` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint | `http://otel-collector:4317` |
 | `OTEL_TRACES_EXPORTER` | Traces exporter (`otlp`, `logging`, `none`) | `otlp` |


### PR DESCRIPTION
#487 re-enabled installation of the OTEL agent at build time, but telemetry export remains disabled at runtime by default.
This PR documents that behaviour by adding the explanation for OTEL_SDK_DISABLED environment variable.